### PR TITLE
Fixed the float error for python 3.11

### DIFF
--- a/src/main/python/utils/toolbar.py
+++ b/src/main/python/utils/toolbar.py
@@ -82,7 +82,7 @@ class toolbar(QDockWidget):
         parent = self.parentWidget() #used to get parent dimensions
         self.layout.setDirection(QBoxLayout.TopToBottom) # here so that a horizontal toolbar can be implemented later
         # self.setFixedHeight(self.height()) #span available height
-        self.searchBox.setMinimumWidth(.18*parent.width())
+        self.searchBox.setMinimumWidth(int(.18*parent.width()))
         width = self.width()
         scrollBar = self.diagArea.verticalScrollBar()
         height = self.diagAreaLayout.heightForWidth(width)
@@ -91,7 +91,7 @@ class toolbar(QDockWidget):
         
         # the following line, sets the required height for the current width, so that blank space doesnt occur
         self.diagAreaWidget.setMinimumHeight(height)
-        self.setMinimumWidth(.2*parent.width()) #12% of parent width
+        self.setMinimumWidth(int(.2*parent.width())) #12% of parent width
         # self.setMinimumWidth(self.diagAreaLayout.minimumSize().width()) #12% of parent width
         self.diagAreaWidget.setLayout(self.diagAreaLayout)
         self.diagArea.setWidget(self.diagAreaWidget)


### PR DESCRIPTION
Error:
TypeError: setMinimumWidth(self, minw: int): argument 1 has unexpected type 'float'
File:Chemical-PFD-master\src\main\python\utils\toolbar.py", line 85, in resize
    self.searchBox.setMinimumWidth(.18*parent.width())

Solution:
By adding a type cast for int() we can resolve this error and it will work perfectly fine in all the previous versions of python